### PR TITLE
Quality of Life - TimeIntervals and Radians

### DIFF
--- a/Sources/RealityActions/ActionManager.swift
+++ b/Sources/RealityActions/ActionManager.swift
@@ -21,7 +21,7 @@ public class ActionManagerSystem : System {
 
 
     public func update(context: SceneUpdateContext) {
-        globalActionManager.update(dt: Float (context.deltaTime))
+        globalActionManager.update(dt: context.deltaTime)
     }
 }
 
@@ -80,7 +80,7 @@ public class ActionManager {
         return element.actionStates.count
     }
     
-    public func update(dt: Float) {
+    public func update(dt: Double) {
         guard targetsAvailable else { return }
         
         let keys = targets.keys

--- a/Sources/RealityActions/Base/Action.swift
+++ b/Sources/RealityActions/Base/Action.swift
@@ -50,14 +50,14 @@ class ActionState {
     
     /// Called every frame with it's delta time.
     /// - Parameter dt: Delta time
-    func step (dt: Float) {
+    func step (dt: TimeInterval) {
         
     }
     
     /// Called once per frame.
     /// - Parameter time: A value between 0 and 1; 0 means that the action just started, 0.5 means the action is in the middle; 1 means the action is over
     ///
-    func update (time: Float) {
+    func update (time: Double) {
         
     }
 }

--- a/Sources/RealityActions/Base/AmplitudeAction.swift
+++ b/Sources/RealityActions/Base/AmplitudeAction.swift
@@ -10,12 +10,12 @@ import RealityKit
 
 class AmplitudeAction: FiniteTimeAction
 {
-    public var amplitude: Float = 0
+    public var amplitude: Double = 0
 }
 
 class AmplitudeActionState: FiniteTimeActionState {
-    var amplitude: Float
-    var amplitudeRate: Float
+    var amplitude: Double
+    var amplitudeRate: Double
     
     init (action: AmplitudeAction, target: Entity) {
         amplitude = action.amplitude

--- a/Sources/RealityActions/Base/FiniteTimeAction.swift
+++ b/Sources/RealityActions/Base/FiniteTimeAction.swift
@@ -11,10 +11,10 @@ import RealityKit
 /// Base class for actions that have a time duration.
 public class FiniteTimeAction: BaseAction {
     /// The duration for this action
-    public let duration: Float
+    public let duration: TimeInterval
     
-    public init (duration: Float) {
-        self.duration = max (Float.ulpOfOne, duration)
+    public init (duration: TimeInterval) {
+        self.duration = max (.ulpOfOne, duration)
     }
     
     /// Produces an action that is the reverse of the current action
@@ -29,8 +29,8 @@ public class FiniteTimeAction: BaseAction {
 
 class FiniteTimeActionState: ActionState {
     var firstTick: Bool
-    var duration: Float
-    var elapsed: Float
+    var duration: TimeInterval
+    var elapsed: TimeInterval
     
     override var isDone: Bool { elapsed >= duration }
     
@@ -41,7 +41,7 @@ class FiniteTimeActionState: ActionState {
         super.init(action: action, target: target)
     }
     
-    override func step (dt: Float) {
+    override func step (dt: TimeInterval) {
         if firstTick {
             firstTick = false
             elapsed = 0
@@ -49,6 +49,6 @@ class FiniteTimeActionState: ActionState {
             elapsed += dt
         }
         
-        update (time: max (0, min (1, elapsed / max (duration, Float.ulpOfOne))))
+        update(time: max (0.0, min (1.0, elapsed / max (duration, TimeInterval.ulpOfOne))))
     }
 }

--- a/Sources/RealityActions/Base/Speed.swift
+++ b/Sources/RealityActions/Base/Speed.swift
@@ -10,7 +10,7 @@ import RealityKit
 
 /// Changes the speed by which the nested action is executed
 public class Speed: BaseAction {
-    public var speedFactor: Float
+    public var speedFactor: Double
     
     var innerAction: FiniteTimeAction
     
@@ -19,7 +19,7 @@ public class Speed: BaseAction {
     ///   - action: Action that will be sped up
     ///   - speedFactor: factor by which time is modified.   For example, the value 2 makes things go twice as fast,
     ///   while the value .1 makes things ten times slower
-    public init (action: FiniteTimeAction, speedFactor: Float) {
+    public init (action: FiniteTimeAction, speedFactor: Double) {
         innerAction = action
         self.speedFactor = speedFactor
     }
@@ -35,7 +35,7 @@ public class Speed: BaseAction {
 
 class SpeedState: ActionState
 {
-    var speed: Float
+    var speed: Double
     var innerActionState: FiniteTimeActionState
     
     override var isDone: Bool {
@@ -57,7 +57,7 @@ class SpeedState: ActionState
         super.stop()
     }
     
-    override func step(dt: Float) {
+    override func step(dt: TimeInterval) {
         innerActionState.step(dt: dt * speed)
     }
 }

--- a/Sources/RealityActions/Ease/ActionEase.swift
+++ b/Sources/RealityActions/Ease/ActionEase.swift
@@ -45,7 +45,7 @@ class ActionEaseState : FiniteTimeActionState {
         super.stop()
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         innerActionState.update (time: time)
     }
 }

--- a/Sources/RealityActions/Ease/EaseBackIn.swift
+++ b/Sources/RealityActions/Ease/EaseBackIn.swift
@@ -28,7 +28,7 @@ class EaseBackInState: ActionEaseState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         innerActionState.update (time: backIn (time: time))
     }
 }

--- a/Sources/RealityActions/Ease/EaseBackInOut.swift
+++ b/Sources/RealityActions/Ease/EaseBackInOut.swift
@@ -28,7 +28,7 @@ class EaseBackInOutState: ActionEaseState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         innerActionState.update (time: backInOut (time: time))
     }
 }

--- a/Sources/RealityActions/Ease/EaseBackOut.swift
+++ b/Sources/RealityActions/Ease/EaseBackOut.swift
@@ -28,7 +28,7 @@ class EaseBackOutState: ActionEaseState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         innerActionState.update (time: backOut (time: time))
     }
 }

--- a/Sources/RealityActions/Ease/EaseBounceIn.swift
+++ b/Sources/RealityActions/Ease/EaseBounceIn.swift
@@ -28,7 +28,7 @@ class EaseBounceInState: ActionEaseState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         innerActionState.update (time: bounceIn (time: time))
     }
 }

--- a/Sources/RealityActions/Ease/EaseBounceInOut.swift
+++ b/Sources/RealityActions/Ease/EaseBounceInOut.swift
@@ -28,7 +28,7 @@ class EaseBounceInOutState: ActionEaseState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         innerActionState.update (time: bounceInOut (time: time))
     }
 }

--- a/Sources/RealityActions/Ease/EaseBounceOut.swift
+++ b/Sources/RealityActions/Ease/EaseBounceOut.swift
@@ -28,7 +28,7 @@ class EaseBounceOutState: ActionEaseState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         innerActionState.update (time: bounceOut (time: time))
     }
 }

--- a/Sources/RealityActions/Ease/EaseCustom.swift
+++ b/Sources/RealityActions/Ease/EaseCustom.swift
@@ -10,14 +10,14 @@ import RealityKit
 
 /// An easing function that can be controlled by passing a function that computes the desired interpolation
 public class EaseCustom: ActionEase {
-    let easeFunc: (Float) -> Float
+    let easeFunc: (Double) -> Double
     
     /// Constructs a custom easing function
     /// - Parameters:
     ///   - action: The action to act on
     ///   - easeFunc: A custom function that takes a floating point value between 0 and 1 representing the time for the easing,
     ///   and which should return a value betwee 0 and 1 for how this time is altered.
-    public init (_ action: FiniteTimeAction, _ easeFunc: @escaping (Float)-> Float) {
+    public init (_ action: FiniteTimeAction, _ easeFunc: @escaping (Double)-> Double) {
         self.easeFunc = easeFunc
         super.init(action)
     }
@@ -32,14 +32,14 @@ public class EaseCustom: ActionEase {
 }
 
 class EaseCustomState: ActionEaseState {
-    let easeFunc: (Float) -> Float
+    let easeFunc: (Double) -> Double
     
     init? (action: EaseCustom, target: Entity) {
         self.easeFunc = action.easeFunc
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         innerActionState.update (time: easeFunc (time))
     }
 }

--- a/Sources/RealityActions/Ease/EaseElastic.swift
+++ b/Sources/RealityActions/Ease/EaseElastic.swift
@@ -11,8 +11,8 @@ import RealityKit
 
 /// Base class for the EaseElastic easing function, use one of those.
 public class EaseElastic: ActionEase {
-    let period: Float
-    public init (_ action: FiniteTimeAction, period: Float = 0.3) {
+    let period: Double
+    public init (_ action: FiniteTimeAction, period: Double = 0.3) {
         self.period = period
         super.init(action)
     }
@@ -27,7 +27,7 @@ public class EaseElastic: ActionEase {
 }
 
 class EaseElasticState: ActionEaseState {
-    let period: Float
+    let period: Double
     init? (action: EaseElastic, target: Entity) {
         self.period = action.period
         super.init(action: action, target: target)

--- a/Sources/RealityActions/Ease/EaseElasticIn.swift
+++ b/Sources/RealityActions/Ease/EaseElasticIn.swift
@@ -10,7 +10,7 @@ import RealityKit
 
 /// Easing function: elastic-in
 public class EaseElasticIn: EaseElastic {
-    public override init (_ action: FiniteTimeAction, period: Float = 0.3) {
+    public override init (_ action: FiniteTimeAction, period: Double = 0.3) {
         super.init(action, period: period)
     }
     
@@ -24,14 +24,14 @@ public class EaseElasticIn: EaseElastic {
 }
 
 class EaseElasticInState: ActionEaseState {
-    let period: Float
+    let period: Double
     
     init? (action: EaseElasticIn, target: Entity) {
         period = action.period
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         innerActionState.update (time: elasticIn (time: time, period: period))
     }
 }

--- a/Sources/RealityActions/Ease/EaseElasticInOut.swift
+++ b/Sources/RealityActions/Ease/EaseElasticInOut.swift
@@ -10,7 +10,7 @@ import RealityKit
 
 /// Easing function: elastic-in-and-then-out
 public class EaseElasticInOut: EaseElastic {
-    public override init (_ action: FiniteTimeAction, period: Float = 0.3) {
+    public override init (_ action: FiniteTimeAction, period: Double = 0.3) {
         super.init(action, period: period)
     }
     
@@ -24,14 +24,14 @@ public class EaseElasticInOut: EaseElastic {
 }
 
 class EaseElasticInOutState: ActionEaseState {
-    let period: Float
+    let period: Double
     
     init? (action: EaseElasticInOut, target: Entity) {
         period = action.period
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         innerActionState.update (time: elasticInOut (time: time, period: period))
     }
 }

--- a/Sources/RealityActions/Ease/EaseElasticOut.swift
+++ b/Sources/RealityActions/Ease/EaseElasticOut.swift
@@ -10,7 +10,7 @@ import RealityKit
 
 /// Easing function: elastic-out
 public class EaseElasticOut: EaseElastic {
-    public override init (_ action: FiniteTimeAction, period: Float = 0.3) {
+    public override init (_ action: FiniteTimeAction, period: Double = 0.3) {
         super.init(action, period: period)
     }
     
@@ -24,14 +24,14 @@ public class EaseElasticOut: EaseElastic {
 }
 
 class EaseElasticOutState: ActionEaseState {
-    let period: Float
+    let period: Double
     
     init? (action: EaseElasticOut, target: Entity) {
         period = action.period
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         innerActionState.update (time: elasticOut (time: time, period: period))
     }
 }

--- a/Sources/RealityActions/Ease/EaseExponentialIn.swift
+++ b/Sources/RealityActions/Ease/EaseExponentialIn.swift
@@ -28,7 +28,7 @@ class EaseExponentialInState: ActionEaseState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         innerActionState.update (time: exponentialIn(time: time))
     }
 }

--- a/Sources/RealityActions/Ease/EaseExponentialInOut.swift
+++ b/Sources/RealityActions/Ease/EaseExponentialInOut.swift
@@ -28,7 +28,7 @@ class EaseExponentialInOutState: ActionEaseState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         innerActionState.update (time: exponentialInOut(time: time))
     }
 }

--- a/Sources/RealityActions/Ease/EaseExponentialOut.swift
+++ b/Sources/RealityActions/Ease/EaseExponentialOut.swift
@@ -28,7 +28,7 @@ class EaseExponentialOutState: ActionEaseState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         innerActionState.update (time: exponentialOut (time: time))
     }
 }

--- a/Sources/RealityActions/Ease/EaseIn.swift
+++ b/Sources/RealityActions/Ease/EaseIn.swift
@@ -10,7 +10,7 @@ import RealityKit
 
 /// Easing function: ease-in
 public class EaseIn: EaseRateAction {
-    public override init (_ action: FiniteTimeAction, rate: Float) {
+    public override init (_ action: FiniteTimeAction, rate: Double) {
         super.init(action, rate: rate)
     }
     
@@ -28,7 +28,7 @@ class EaseInState: EaseRateActionState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
-        innerActionState.update (time: powf(time, rate))
+    override func update(time: Double) {
+        innerActionState.update (time: pow(time, rate))
     }
 }

--- a/Sources/RealityActions/Ease/EaseInOut.swift
+++ b/Sources/RealityActions/Ease/EaseInOut.swift
@@ -10,7 +10,7 @@ import RealityKit
 
 /// Easing function: ease-in-and-then-out
 public class EaseInOut: EaseRateAction {
-    public override init (_ action: FiniteTimeAction, rate: Float) {
+    public override init (_ action: FiniteTimeAction, rate: Double) {
         super.init(action, rate: rate)
     }
     
@@ -28,12 +28,12 @@ class EaseInOutState: EaseRateActionState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         let atime = time * 2
         if atime < 2 {
-            innerActionState.update (time: 0.5 * powf (atime, rate))
+            innerActionState.update (time: 0.5 * pow (atime, rate))
         } else {
-            innerActionState.update (time: 1 - 0.5 * powf (2-atime, rate))
+            innerActionState.update (time: 1 - 0.5 * pow (2-atime, rate))
         }
     }
 }

--- a/Sources/RealityActions/Ease/EaseOut.swift
+++ b/Sources/RealityActions/Ease/EaseOut.swift
@@ -10,7 +10,7 @@ import RealityKit
 
 /// Easing function: ease-out
 public class EaseOut: EaseRateAction {
-    public override init (_ action: FiniteTimeAction, rate: Float) {
+    public override init (_ action: FiniteTimeAction, rate: Double) {
         super.init(action, rate: rate)
     }
     
@@ -28,7 +28,7 @@ class EaseOutState: EaseRateActionState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
-        innerActionState.update (time: powf(time, 1/rate))
+    override func update(time: Double) {
+        innerActionState.update (time: pow(time, 1/rate))
     }
 }

--- a/Sources/RealityActions/Ease/EaseRateAction.swift
+++ b/Sources/RealityActions/Ease/EaseRateAction.swift
@@ -10,8 +10,8 @@ import RealityKit
 
 /// Base class for easing function with rate parameters
 public class EaseRateAction: ActionEase {
-    let rate: Float
-    public init (_ action: FiniteTimeAction, rate: Float) {
+    let rate: Double
+    public init (_ action: FiniteTimeAction, rate: Double) {
         self.rate = rate
         super.init(action)
     }
@@ -26,13 +26,13 @@ public class EaseRateAction: ActionEase {
 }
 
 class EaseRateActionState: ActionEaseState {
-    let rate: Float
+    let rate: Double
     init? (action: EaseRateAction, target: Entity) {
         rate = action.rate
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         innerActionState.update (time: exponentialOut(time: time))
     }
 }

--- a/Sources/RealityActions/Ease/EaseSinIn.swift
+++ b/Sources/RealityActions/Ease/EaseSinIn.swift
@@ -28,7 +28,7 @@ class EaseSinInState: ActionEaseState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         innerActionState.update (time: sineIn (time: time))
     }
 }

--- a/Sources/RealityActions/Ease/EaseSinInOut.swift
+++ b/Sources/RealityActions/Ease/EaseSinInOut.swift
@@ -28,7 +28,7 @@ class EaseSinInOutState: ActionEaseState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         innerActionState.update (time: sineInOut (time: time))
     }
 }

--- a/Sources/RealityActions/Ease/EaseSinOut.swift
+++ b/Sources/RealityActions/Ease/EaseSinOut.swift
@@ -28,7 +28,7 @@ class EaseSinOutState: ActionEaseState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         innerActionState.update (time: sineOut (time: time))
     }
 }

--- a/Sources/RealityActions/EaseMath.swift
+++ b/Sources/RealityActions/EaseMath.swift
@@ -7,21 +7,21 @@
 
 import Foundation
 
-func backIn(time: Float) -> Float {
-    let overshoot: Float = 1.70158
+func backIn(time: Double) -> Double {
+    let overshoot: Double = 1.70158
     
     return time * time * ((overshoot + 1) * time - overshoot)
 }
 
-func backOut(time: Float) -> Float {
-    let overshoot: Float = 1.70158
+func backOut(time: Double) -> Double {
+    let overshoot: Double = 1.70158
     
     let time = time - 1
     return time * time * ((overshoot + 1) * time + overshoot) + 1
 }
 
-func backInOut(time: Float) -> Float {
-    let overshoot: Float = 1.70158 * 1.525
+func backInOut(time: Double) -> Double {
+    let overshoot: Double = 1.70158 * 1.525
     
     let time = time * 2
     if time < 1 {
@@ -32,7 +32,7 @@ func backInOut(time: Float) -> Float {
     }
 }
 
-func bounceOut(time: Float) -> Float {
+func bounceOut(time: Double) -> Double {
     if time < 1 / 2.75 {
         return 7.5625 * time * time
     } else if (time < 2 / 2.75) {
@@ -47,11 +47,11 @@ func bounceOut(time: Float) -> Float {
     return 7.5625 * utime * utime + 0.984375
 }
 
-func bounceIn(time: Float) -> Float {
+func bounceIn(time: Double) -> Double {
     return 1 - bounceOut(time: 1 - time)
 }
 
-func bounceInOut(time: Float) -> Float {
+func bounceInOut(time: Double) -> Double {
     if time < 0.5 {
         let time = time * 2
         return (1 - bounceOut(time: 1 - time)) * 0.5
@@ -59,55 +59,55 @@ func bounceInOut(time: Float) -> Float {
     return bounceOut(time: time * 2 - 1) * 0.5 + 0.5
 }
 
-func sineOut(time: Float) -> Float {
+func sineOut(time: Double) -> Double {
     sin (time * .pi/2)
 }
 
-func sineIn(time: Float) -> Float {
+func sineIn(time: Double) -> Double {
     -1 * cos(time * .pi/2) + 1
 }
 
-func sineInOut(time: Float) -> Float {
+func sineInOut(time: Double) -> Double {
     -0.5 * (cos(.pi * time) - 1)
 }
 
-func exponentialOut(time: Float) -> Float {
-    time == 1 ? 1 : (-powf(2, -10 * time / 1) + 1)
+func exponentialOut(time: Double) -> Double {
+    time == 1 ? 1 : (-pow(2, -10 * time / 1) + 1)
 }
 
-func exponentialIn(time: Float) -> Float {
-    time == 0 ? 0 : powf(2, 10 * (time / 1 - 1)) - 1 * 0.001
+func exponentialIn(time: Double) -> Double {
+    time == 0 ? 0 : pow(2, 10 * (time / 1 - 1)) - 1 * 0.001
 }
 
-func exponentialInOut(time: Float) -> Float {
+func exponentialInOut(time: Double) -> Double {
     let time = time / 0.5
     if time < 1 {
-        return 0.5 * powf(2, 10 * (time - 1))
+        return 0.5 * pow(2, 10 * (time - 1))
     } else {
-        return 0.5 * (-powf(2, -10 * (time - 1)) + 2)
+        return 0.5 * (-pow(2, -10 * (time - 1)) + 2)
     }
 }
 
-func elasticIn(time: Float, period: Float) -> Float {
+func elasticIn(time: Double, period: Double) -> Double {
     if time == 0 || time == 1 {
         return time
     } else {
         let s = period / 4
         let rtime = time - 1
-        return -(powf(2, 10 * rtime) * sin((rtime - s) * .pi * 2 / period))
+        return -(pow(2, 10 * rtime) * sin((rtime - s) * .pi * 2 / period))
     }
 }
 
-func elasticOut(time: Float, period: Float) -> Float {
+func elasticOut(time: Double, period: Double) -> Double {
     if time == 0 || time == 1 {
         return time
     } else {
         let s = period / 4
-        return powf (2, -10 * time) * sin((time - s) * .pi * 2 / period) + 1
+        return pow (2, -10 * time) * sin((time - s) * .pi * 2 / period) + 1
     }
 }
 
-func elasticInOut(time: Float, period: Float) -> Float {
+func elasticInOut(time: Double, period: Double) -> Double {
     if time == 0 || time == 1 {
         return time
     } else {
@@ -116,9 +116,9 @@ func elasticInOut(time: Float, period: Float) -> Float {
         let s = period / 4
         
         if time < 0 {
-            return (-0.5 * powf(2, 10 * time) * sin((time - s) * .pi * 2 / period))
+            return (-0.5 * pow(2, 10 * time) * sin((time - s) * .pi * 2 / period))
         } else {
-            return powf(2, -10 * time) * sin((time - s) * .pi*2 / period) * 0.5 + 1
+            return pow(2, -10 * time) * sin((time - s) * .pi*2 / period) * 0.5 + 1
         }
     }
 }

--- a/Sources/RealityActions/Instants/ActionInstant.swift
+++ b/Sources/RealityActions/Instants/ActionInstant.swift
@@ -32,11 +32,11 @@ class ActionInstantState: FiniteTimeActionState {
     
     override var isDone: Bool { true }
     
-    override func step(dt: Float) {
+    override func step(dt: TimeInterval) {
         update (time: 1)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         // ignore
     }
 }

--- a/Sources/RealityActions/Instants/AsyncSupport.swift
+++ b/Sources/RealityActions/Instants/AsyncSupport.swift
@@ -28,7 +28,7 @@ class AsyncSupportState: ActionInstantState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         if let cc = aas.cc {
             aas.cc = nil
             cc.resume()

--- a/Sources/RealityActions/Instants/Call.swift
+++ b/Sources/RealityActions/Instants/Call.swift
@@ -31,7 +31,7 @@ class CallState: ActionInstantState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         call.callback ()
     }
 }

--- a/Sources/RealityActions/Instants/RemoveSelf.swift
+++ b/Sources/RealityActions/Instants/RemoveSelf.swift
@@ -24,7 +24,7 @@ class RemoveSelfState: ActionInstantState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         guard let target else { return }
         target.parent?.removeChild(target)
     }

--- a/Sources/RealityActions/Intervals/ActionTween.swift
+++ b/Sources/RealityActions/Intervals/ActionTween.swift
@@ -21,7 +21,7 @@ public class ActionTween: FiniteTimeAction {
     ///   - from: Initial value
     ///   - to: Final value
     ///   - tweenAction: The callback that will be invoked repeatedly with the computed value in the range `from`..`to` interpolated into the duration.
-    public init (duration: Float, from: Float, to: Float, tweenAction: @escaping (Float)->())
+    public init (duration: TimeInterval, from: Float, to: Float, tweenAction: @escaping (Float)->())
     {
         self.to = to
         self.from = from
@@ -49,8 +49,8 @@ class ActionTweenState : FiniteTimeActionState
         super.init (action: action, target: target)
     }
     
-    override func update(time: Float) {
-        let amt = at.to - delta * (1 - time)
+    override func update(time: Double) {
+        let amt = at.to - delta * Float(1 - time)
         at.tweenAction (amt)
     }
 }

--- a/Sources/RealityActions/Intervals/BezierBy.swift
+++ b/Sources/RealityActions/Intervals/BezierBy.swift
@@ -11,7 +11,7 @@ import RealityKit
 public class BezierBy: FiniteTimeAction {
     let bezierConfig: BezierConfig
     
-    public init (duration: Float, config: BezierConfig) {
+    public init (duration: TimeInterval, config: BezierConfig) {
         bezierConfig = config
         super.init(duration: duration)
     }
@@ -42,7 +42,7 @@ class BezierByState: FiniteTimeActionState {
         super.init (action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         guard let target else { return }
         
         let xa: Float = 0
@@ -60,9 +60,9 @@ class BezierByState: FiniteTimeActionState {
         let zc: Float = bezierConfig.controlPoint2.z
         let zd: Float = bezierConfig.endPosition.z
         
-        let x: Float = cubicBezier (a: xa, b: xb, c: xc, d: xd, t: time)
-        let y: Float = cubicBezier (a: ya, b: yb, c: yc, d: yd, t: time)
-        let z: Float = cubicBezier (a: za, b: zb, c: zc, d: zd, t: time)
+        let x: Float = cubicBezier (a: xa, b: xb, c: xc, d: xd, t: Float(time))
+        let y: Float = cubicBezier (a: ya, b: yb, c: yc, d: yd, t: Float(time))
+        let z: Float = cubicBezier (a: za, b: zb, c: zc, d: zd, t: Float(time))
         
         let currentPos = target.position
         let diff = currentPos - previousPosition

--- a/Sources/RealityActions/Intervals/BezierTo.swift
+++ b/Sources/RealityActions/Intervals/BezierTo.swift
@@ -16,7 +16,7 @@ public class BezierTo: BezierBy {
     /// - Parameters:
     ///   - duration: How long will the transition take place
     ///   - config: Configuration specifying the two control points and the end position
-    public override init (duration: Float, config: BezierConfig) {
+    public override init (duration: TimeInterval, config: BezierConfig) {
         super.init(duration: duration, config: config)
     }
     

--- a/Sources/RealityActions/Intervals/Blink.swift
+++ b/Sources/RealityActions/Intervals/Blink.swift
@@ -11,7 +11,7 @@ import RealityKit
 /// Action to blink the target based on the duration
 public class Blink: FiniteTimeAction {
     let count: Int
-    public init (duration: Float, count: Int) {
+    public init (duration: TimeInterval, count: Int) {
         self.count = count
         super.init(duration: duration)
     }
@@ -35,10 +35,10 @@ class BlinkState: FiniteTimeActionState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         guard let target else { return }
         guard !isDone else { return }
-        let slice = 1.0 / Float(count)
+        let slice = 1.0 / Double(count)
         let m = fmod (time, slice)
         target.isEnabled = m > (slice/2)
     }

--- a/Sources/RealityActions/Intervals/DelayTime.swift
+++ b/Sources/RealityActions/Intervals/DelayTime.swift
@@ -10,7 +10,7 @@ import RealityKit
 
 /// An action which completes after the specified time.
 public class DelayTime: FiniteTimeAction {
-    public override init (duration: Float) {
+    public override init (duration: TimeInterval) {
         super.init(duration: duration)
     }
     
@@ -28,6 +28,6 @@ class DelayTimeState: FiniteTimeActionState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
     }
 }

--- a/Sources/RealityActions/Intervals/ExtraAction.swift
+++ b/Sources/RealityActions/Intervals/ExtraAction.swift
@@ -10,7 +10,7 @@ import RealityKit
 
 // Extra action for making a Sequence or Spawn when only adding one action to it.
 class ExtraAction: FiniteTimeAction {
-    public override init (duration: Float) {
+    public override init (duration: TimeInterval) {
         super.init(duration: duration)
     }
     
@@ -28,8 +28,8 @@ class ExtraActionState: FiniteTimeActionState {
         super.init(action: action, target: target)
     }
     
-    override func step(dt: Float) {
+    override func step(dt: TimeInterval) {
     }
-    override func update(time: Float) {
+    override func update(time: Double) {
     }
 }

--- a/Sources/RealityActions/Intervals/FadeIn.swift
+++ b/Sources/RealityActions/Intervals/FadeIn.swift
@@ -10,7 +10,7 @@ import RealityKit
 
 // Extra action for making a Sequence or Spawn when only adding one action to it.
 class FadeIn: FiniteTimeAction {
-    public override init (duration: Float) {
+    public override init (duration: TimeInterval) {
         super.init(duration: duration)
         fatalError()
     }
@@ -29,8 +29,8 @@ class FadeInState: FiniteTimeActionState {
         super.init(action: action, target: target)
     }
     
-    override func step(dt: Float) {
+    override func step(dt: TimeInterval) {
     }
-    override func update(time: Float) {
+    override func update(time: Double) {
     }
 }

--- a/Sources/RealityActions/Intervals/IntervalCall.swift
+++ b/Sources/RealityActions/Intervals/IntervalCall.swift
@@ -10,14 +10,14 @@ import RealityKit
 
 /// Calls a user-provided method over the specified time span, useful as a method to call inside the easing functions
 public class IntervalCall: FiniteTimeAction {
-    let callback: (Float)-> ()
+    let callback: (Double)-> ()
     
     
     /// Initializes an `IntervalCall`
     /// - Parameters:
     ///   - duration: Time period in which the callback will be invoked
     ///   - callback: The method that will be invoked, it takes a float parameter in the range 0...1.0 representing the time
-    public init (duration: Float, _ callback: @escaping (Float) -> ()) {
+    public init (duration: TimeInterval, _ callback: @escaping (Double) -> ()) {
         self.callback = callback
         super.init(duration: duration)
     }
@@ -28,14 +28,14 @@ public class IntervalCall: FiniteTimeAction {
 }
 
 class IntervalCallState: FiniteTimeActionState {
-    let callback: (Float) -> ()
+    let callback: (Double) -> ()
     
     init(action: IntervalCall, target: Entity) {
         self.callback = action.callback
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         guard target != nil else { return }
 
         callback (time)

--- a/Sources/RealityActions/Intervals/JumpBy.swift
+++ b/Sources/RealityActions/Intervals/JumpBy.swift
@@ -11,10 +11,10 @@ import RealityKit
 /// Moves a Node object simulating a parabolic jump movement by modifying it's position attribute.
 public class JumpBy: FiniteTimeAction {
     let jumps: Int
-    let height: Float
+    let height: Double
     let position: SIMD3<Float>
     
-    public init (duration: Float, position: SIMD3<Float>, height: Float, jumps: Int) {
+    public init (duration: TimeInterval, position: SIMD3<Float>, height: Double, jumps: Int) {
         self.jumps = jumps
         self.height = height
         self.position = position
@@ -45,11 +45,12 @@ class JumpByState: FiniteTimeActionState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         guard let target else { return }
-        let frac = fmod (time * Float (aj.jumps), 1)
-        let y = aj.height * 4 * frac * (1 - frac)
-        let delta: SIMD3<Float> = [delta.x * time, y * time, delta.z * time]
+        let fTime = Float(time)
+        let frac = fmod (time * Double (aj.jumps), 1)
+        let y = Float(aj.height * 4 * frac * (1 - frac))
+        let delta: SIMD3<Float> = [delta.x * fTime, y * fTime, delta.z * fTime]
         
         let currentPos = target.position
         

--- a/Sources/RealityActions/Intervals/JumpTo.swift
+++ b/Sources/RealityActions/Intervals/JumpTo.swift
@@ -10,7 +10,7 @@ import RealityKit
 
 /// Moves a Node object to a parabolic position simulating a jump movement by modifying it's position attribute.
 public class JumpTo: JumpBy {
-    public override init (duration: Float, position: SIMD3<Float>, height: Float, jumps: Int) {
+    public override init (duration: TimeInterval, position: SIMD3<Float>, height: Double, jumps: Int) {
         super.init(duration: duration, position: position, height: height, jumps: jumps)
     }
     

--- a/Sources/RealityActions/Intervals/MoveBy.swift
+++ b/Sources/RealityActions/Intervals/MoveBy.swift
@@ -12,7 +12,7 @@ import RealityKit
 public class MoveBy: FiniteTimeAction {
     let delta: SIMD3<Float>
     
-    public init (duration: Float, delta: SIMD3<Float>) {
+    public init (duration: TimeInterval, delta: SIMD3<Float>) {
         self.delta = delta
         super.init(duration: duration)
     }
@@ -40,14 +40,10 @@ class MoveByState: FiniteTimeActionState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         guard let target else { return }
-        //let currentPos = target.position
-//        let diff = currentPos - previousPosition
-//        startPosition = diff + startPosition
-        
-        //print ("startPosition=\(startPosition) delta=\(delta) time=\(time)")
-        let newPos = startPosition + delta * time
+
+        let newPos = startPosition + delta * Float(time)
         target.position = newPos
         
         previousPosition = newPos

--- a/Sources/RealityActions/Intervals/MoveTo.swift
+++ b/Sources/RealityActions/Intervals/MoveTo.swift
@@ -14,7 +14,7 @@ import RealityKit
 public class MoveTo: MoveBy {
     var endPosition: SIMD3<Float>
     
-    public init (duration: Float, position: SIMD3<Float>) {
+    public init (duration: TimeInterval, position: SIMD3<Float>) {
         endPosition = position
         super.init(duration: duration, delta: position)
     }
@@ -30,10 +30,10 @@ class MoveToState: MoveByState {
         super.init(action: action, target: target, delta: positionDelta)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         guard let target else { return }
         
-        let newPos = startPosition + delta * time
+        let newPos = startPosition + delta * Float(time)
         target.position = newPos
         previousPosition = newPos
     }

--- a/Sources/RealityActions/Intervals/Parallel.swift
+++ b/Sources/RealityActions/Intervals/Parallel.swift
@@ -21,7 +21,7 @@ public class Parallel: FiniteTimeAction {
     /// Creates a parallel action
     /// - Parameter actions: The nested actions that will be ran in parallel.
     public init (_ actions: [FiniteTimeAction]) {
-        var maxDuration: Float = 0
+        var maxDuration: TimeInterval = 0
         
         for action in actions {
             if action.duration > maxDuration {
@@ -57,6 +57,10 @@ public class Parallel: FiniteTimeAction {
     }
 }
 
+/// For those used to the SceneKit nomenclature, a Group is the same thing as a set of parallel actions.
+///
+public typealias Group = Parallel
+
 class ParallelState: FiniteTimeActionState {
     let ap: Parallel
     var actionStates: [ActionState]
@@ -78,7 +82,7 @@ class ParallelState: FiniteTimeActionState {
         super.stop()
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         for astate in actionStates {
             astate.update(time: time)
         }

--- a/Sources/RealityActions/Intervals/Repeat.swift
+++ b/Sources/RealityActions/Intervals/Repeat.swift
@@ -26,7 +26,7 @@ public class Repeat: FiniteTimeAction {
         } else {
             self.count = count
         }
-        super.init (duration: action.duration * Float (count))
+        super.init (duration: action.duration * Double (count))
     }
     
     override func startAction(target: Entity) -> ActionState? {
@@ -41,7 +41,7 @@ public class Repeat: FiniteTimeAction {
 class RepeatState: FiniteTimeActionState {
     let ra: Repeat
     var total: Int
-    var nextDt: Float
+    var nextDt: Double
     var innerActionState: FiniteTimeActionState
     
     init(action: Repeat, target: Entity) {
@@ -60,7 +60,7 @@ class RepeatState: FiniteTimeActionState {
     // legacy comment, predates CocosSharp:
     // issue #80. Instead of hooking step:, hook update: since it can be called by any
     // container action like Repeat, Sequence, AelDeel, etc..
-    override func update(time: Float) {
+    override func update(time: Double) {
         guard let target else { return }
         if time > nextDt {
             while time > nextDt && ra.count < total {
@@ -69,7 +69,7 @@ class RepeatState: FiniteTimeActionState {
                 
                 innerActionState.stop ()
                 innerActionState = ra.innerAction.startAction (target: target) as! FiniteTimeActionState
-                nextDt = ra.innerAction.duration / duration * Float (total+1)
+                nextDt = ra.innerAction.duration / duration * Double (total+1)
             }
             
             // LEGACY COMMENT fix for issue #1288, incorrect end value of repeat
@@ -88,7 +88,7 @@ class RepeatState: FiniteTimeActionState {
                 }
             }
         } else {
-            innerActionState.update(time: fmod (time * Float (ra.count), 1.0))
+            innerActionState.update(time: fmod (time * Double (ra.count), 1.0))
         }
     }
 }

--- a/Sources/RealityActions/Intervals/RepeatForever.swift
+++ b/Sources/RealityActions/Intervals/RepeatForever.swift
@@ -51,7 +51,7 @@ class RepeatForeverState: FiniteTimeActionState {
         super.init(action: action, target: target)
     }
     
-    override func step(dt: Float) {
+    override func step(dt: TimeInterval) {
         guard let target else { return }
         innerActionState.step(dt: dt)
         if innerActionState.isDone {

--- a/Sources/RealityActions/Intervals/ReverseTime.swift
+++ b/Sources/RealityActions/Intervals/ReverseTime.swift
@@ -44,7 +44,7 @@ class ReverseTimeState: FiniteTimeActionState {
         otherState.stop()
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         otherState.update(time: 1-time)
     }
 }

--- a/Sources/RealityActions/Intervals/RotateBy.swift
+++ b/Sources/RealityActions/Intervals/RotateBy.swift
@@ -8,19 +8,32 @@
 import Foundation
 import RealityKit
 
-/// Rotates the transformation of the target by the specified degrees
+/// Rotates the transformation of the target by the specified radians
 public class RotateBy: FiniteTimeAction {
+    
+    // The angle in radians
     let deltaAngles: SIMD3<Float>
     
+    let deg2radians: Float = .pi / 180
+
     /// Creates a rotation
     /// - Parameters:
     ///   - duration: time for the rotation to take place
-    ///   - deltaAngles: this vector contains the angle values in X, Y and Z that you want to perform
-    public init (duration: Float, deltaAngles: SIMD3<Float>) {
-        self.deltaAngles = deltaAngles
+    ///   - deltaAngles: this vector contains the angle values in X, Y and Z in degrees that you want to perform
+    public init (duration: TimeInterval, deltaAngles: SIMD3<Float>) {
+        self.deltaAngles = deltaAngles * deg2radians
         super.init(duration: duration)
     }
-    
+
+    /// Creates a rotation
+    /// - Parameters:
+    ///   - duration: time for the rotation to take place
+    ///   - deltaAngles: this vector contains the angle values in X, Y and Z i radians that you want to perform
+    public init (duration: TimeInterval, deltaAnglesRad: SIMD3<Float>) {
+        self.deltaAngles = deltaAnglesRad
+        super.init(duration: duration)
+    }
+
     override func startAction(target: Entity) -> ActionState? {
         RotateByState (action: self, target: target, deltaAngles: deltaAngles)
     }
@@ -42,12 +55,10 @@ class RotateByState: FiniteTimeActionState {
         self.deltaAngles = deltaAngles
         super.init(action: action, target: target)
     }
-    
-    let deg2radians2: Float = .pi / 360
-    
-    override func update(time: Float) {
+
+    override func update(time: Double) {
         guard let target else { return }
-        let newRot = startRotation * quaternionFromEuler(angles: deltaAngles * time)
+        let newRot = startRotation * quaternionFromEuler(angles: deltaAngles * Float(time))
         target.transform.rotation = newRot.normalized
     }
 }

--- a/Sources/RealityActions/Intervals/RotateTo.swift
+++ b/Sources/RealityActions/Intervals/RotateTo.swift
@@ -8,16 +8,28 @@
 import Foundation
 import RealityKit
 
-/// Rotates the transformation of the target by the specified degrees
+/// Rotates the transformation of the target by the specified radians
 public class RotateTo: FiniteTimeAction {
+    // The angle in radians
     let distanceAngle: SIMD3<Float>
+    
+    let deg2radians: Float = .pi / 360
+
+    /// Creates a rotation
+    /// - Parameters:
+    ///   - duration: time for the rotation to take place
+    ///   - deltaAngles: this vector contains the angle values in X, Y and Z in degrees that you want to perform
+    public init (duration: TimeInterval, distanceAngle: SIMD3<Float>) {
+        self.distanceAngle = distanceAngle * deg2radians
+        super.init(duration: duration)
+    }
     
     /// Creates a rotation
     /// - Parameters:
     ///   - duration: time for the rotation to take place
-    ///   - deltaAngles: this vector contains the angle values in X, Y and Z that you want to perform
-    public init (duration: Float, distanceAngle: SIMD3<Float>) {
-        self.distanceAngle = distanceAngle
+    ///   - deltaAngles: this vector contains the angle values in X, Y and Z in radians that you want to perform
+    public init (duration: TimeInterval, distanceAngleRad: SIMD3<Float>) {
+        self.distanceAngle = distanceAngleRad
         super.init(duration: duration)
     }
     
@@ -37,6 +49,9 @@ class RotateToState: FiniteTimeActionState {
     var diffAngleX, diffAngleY, diffAngleZ: Float
     var startAngleX, startAngleY, startAngleZ: Float
     
+    let deg360 : Float = .pi * 2.0
+    let deg180 : Float = .pi
+    
     init(action: RotateTo, target: Entity) {
         rt = action
         distanceAngle = action.distanceAngle
@@ -44,46 +59,47 @@ class RotateToState: FiniteTimeActionState {
         
         // Calculate X
         startAngleX = sourceRotation.x
-        startAngleX = startAngleX > 0 ? startAngleX.truncatingRemainder(dividingBy: 360.0) : startAngleX.truncatingRemainder(dividingBy: -360.0)
+        startAngleX = startAngleX > 0 ? startAngleX.truncatingRemainder(dividingBy: deg360) : startAngleX.truncatingRemainder(dividingBy: -deg360)
         diffAngleX = distanceAngle.x - startAngleX
-        if diffAngleX > 180 {
-            diffAngleX -= 360
+        if diffAngleX > deg180 {
+            diffAngleX -= deg360
         }
-        if diffAngleX < -180 {
-            diffAngleX += 360
+        if diffAngleX < -deg180 {
+            diffAngleX += deg360
         }
         
         //Calculate Y
         startAngleY = sourceRotation.y
-        startAngleY = startAngleY > 0 ? startAngleY.truncatingRemainder(dividingBy: 360.0) : startAngleY.truncatingRemainder(dividingBy: -360.0)
+        startAngleY = startAngleY > 0 ? startAngleY.truncatingRemainder(dividingBy: deg360) : startAngleY.truncatingRemainder(dividingBy: -deg360)
         diffAngleY = distanceAngle.y - startAngleY
-        if diffAngleY > 180 {
-            diffAngleY -= 360
+        if diffAngleY > deg180 {
+            diffAngleY -= deg360
         }
-        if diffAngleY < -180 {
-            diffAngleY += 360
+        if diffAngleY < -deg180 {
+            diffAngleY += deg360
         }
         
         //Calculate Z
         startAngleZ = sourceRotation.z
-        startAngleZ = startAngleZ > 0 ? startAngleZ.truncatingRemainder(dividingBy: 360.0) : startAngleZ.truncatingRemainder(dividingBy: -360.0)
+        startAngleZ = startAngleZ > 0 ? startAngleZ.truncatingRemainder(dividingBy: deg360) : startAngleZ.truncatingRemainder(dividingBy: -deg360)
         diffAngleZ = distanceAngle.z - startAngleZ
-        if diffAngleZ > 180 {
-            diffAngleZ -= 360
+        if diffAngleZ > deg180 {
+            diffAngleZ -= deg360
         }
-        if diffAngleZ < -180 {
-            diffAngleZ += 360
+        if diffAngleZ < -deg180 {
+            diffAngleZ += deg360
         }
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         guard let target else { return }
-
+        let fTime = Float(time)
+        
         target.transform.rotation = quaternionFromEuler(
             angles: SIMD3<Float> (
-                startAngleX+diffAngleX * time,
-                startAngleY+diffAngleY * time,
-                startAngleZ+diffAngleZ * time))
+                startAngleX+diffAngleX * fTime,
+                startAngleY+diffAngleY * fTime,
+                startAngleZ+diffAngleZ * fTime))
     }
 }

--- a/Sources/RealityActions/Intervals/ScaleBy.swift
+++ b/Sources/RealityActions/Intervals/ScaleBy.swift
@@ -16,12 +16,12 @@ public class ScaleBy: ScaleTo {
     /// - Parameters:
     ///   - duration: The duration for the scaling process
     ///   - scale: The delta for the scale operation
-    public override init (duration: Float, scale: SIMD3<Float>) {
+    public override init (duration: TimeInterval, scale: SIMD3<Float>) {
         self.scale = scale
         super.init(duration: duration, scale: scale)
     }
     
-    public convenience init (duration: Float, scale: Float) {
+    public convenience init (duration: TimeInterval, scale: Float) {
         self.init (duration: duration, scale: SIMD3<Float> (scale, scale, scale))
     }
     

--- a/Sources/RealityActions/Intervals/ScaleTo.swift
+++ b/Sources/RealityActions/Intervals/ScaleTo.swift
@@ -16,7 +16,7 @@ public class ScaleTo: FiniteTimeAction {
     /// - Parameters:
     ///   - duration: The duration for the scaling process
     ///   - scale: The desired scale, represented as a vector for the X, Y and Z components
-    public init (duration: Float, scale: SIMD3<Float>) {
+    public init (duration: TimeInterval, scale: SIMD3<Float>) {
         self.finalScale = scale
         super.init(duration: duration)
     }
@@ -25,7 +25,7 @@ public class ScaleTo: FiniteTimeAction {
     /// - Parameters:
     ///   - duration: The duration for the scaling process
     ///   - scale: The desired scale which is applied uniformly to the x, y and z components
-    public convenience init (duration: Float, scale: Float) {
+    public convenience init (duration: TimeInterval, scale: Float) {
         self.init (duration: duration, scale: SIMD3<Float> (scale, scale, scale))
     }
     
@@ -53,8 +53,8 @@ class ScaleToState: FiniteTimeActionState {
         super.init(action: action, target: target)
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         guard let target else { return }
-        target.transform.scale = startScale + delta * time
+        target.transform.scale = startScale + delta * Float(time)
     }
 }

--- a/Sources/RealityActions/Intervals/SequenceAction.swift
+++ b/Sources/RealityActions/Intervals/SequenceAction.swift
@@ -35,7 +35,7 @@ public class SequenceAction: FiniteTimeAction {
     public init (_ actions: [FiniteTimeAction]) {
         var prev: FiniteTimeAction? = nil
         
-        var combinedDuration: Float = 0
+        var combinedDuration: TimeInterval = 0
         var count = 0
         for action in actions {
             if prev == nil {
@@ -84,7 +84,7 @@ class SequenceActionState: FiniteTimeActionState {
     let action1, action2: FiniteTimeAction
     var action1state, action2state: ActionState?
     let hasInfiniteAction: Bool
-    let split: Float
+    let split: TimeInterval
     var last: ActiveAction
     var id: Int
     
@@ -119,7 +119,7 @@ class SequenceActionState: FiniteTimeActionState {
         }
     }
     
-    override func step(dt: Float) {
+    override func step(dt: TimeInterval) {
         switch last {
         case .none:
             break
@@ -138,11 +138,11 @@ class SequenceActionState: FiniteTimeActionState {
 
     }
     
-    override func update(time: Float) {
+    override func update(time: Double) {
         guard let target else { return }
         var found: ActiveAction
         var foundState: ActionState?
-        var new_t: Float
+        var new_t: Double
         
         if time < split {
             found = .first

--- a/Sources/RealityActions/Intervals/Spawn.swift
+++ b/Sources/RealityActions/Intervals/Spawn.swift
@@ -69,7 +69,7 @@ class SpawnState: FiniteTimeActionState {
         a2state?.stop()
         super.stop()
     }
-    override func update(time: Float) {
+    override func update(time: Double) {
         guard target != nil else { return }
         a1state?.update(time: time)
         a2state?.update(time: time)

--- a/Sources/RealityActions/QuatMath.swift
+++ b/Sources/RealityActions/QuatMath.swift
@@ -8,11 +8,13 @@
 import Foundation
 import RealityKit
 
+/// Converts the incoming euler angles (in radians) to a quaternion.
+/// - Parameter angles: the euler angles in radians
+/// - Returns: the equivalent quaternian.
 func quaternionFromEuler (angles: SIMD3<Float>) -> simd_quatf {
-    let deg2radians2: Float = .pi / 360
-    let rangles = angles * deg2radians2
-    let s = sin (rangles)
-    let c = cos (rangles)
+    let halfAngles = angles / 2.0
+    let s = sin (halfAngles)
+    let c = cos (halfAngles)
     
     return simd_quatf (vector: [
         c.y * s.x * c.z + s.y * c.x * s.z,
@@ -22,6 +24,9 @@ func quaternionFromEuler (angles: SIMD3<Float>) -> simd_quatf {
     ])
 }
 
+/// Converts the input quaternian into euler angles (in radians).
+/// - Parameter quat: the quaternian to convert
+/// - Returns: the equivalent euler angles in radians
 func toEulerAngles (_ quat: simd_quatf) -> SIMD3<Float> {
     // Derivation from http://www.geometrictools.com/Documentation/EulerAngles.pdf
     // Order of rotations: Z first, then X, then Y
@@ -29,19 +34,17 @@ func toEulerAngles (_ quat: simd_quatf) -> SIMD3<Float> {
 
     let check: Float = 2.0*(-qv.y*qv.z + qv.w*qv.x);
     
-    let radToDeg: Float = 180.0 / .pi
-
     if check < -0.995 {
-        return SIMD3<Float> (-90, 0,
-                              -atan2f(2.0 * (qv.x * qv.z - qv.w * qv.y), 1.0 - 2.0 * (qv.y * qv.y + qv.z * qv.z)) * radToDeg)
+        return SIMD3<Float> (-.pi / 2.0, 0,
+                              -atan2f(2.0 * (qv.x * qv.z - qv.w * qv.y), 1.0 - 2.0 * (qv.y * qv.y + qv.z * qv.z)))
     } else if check > 0.995 {
-        return SIMD3<Float> (-90, 0,
-                              atan2f(2.0 * (qv.x * qv.z - qv.w * qv.y), 1.0 - 2.0 * (qv.y * qv.y + qv.z * qv.z)) * radToDeg)
+        return SIMD3<Float> (-.pi / 2.0, 0,
+                              atan2f(2.0 * (qv.x * qv.z - qv.w * qv.y), 1.0 - 2.0 * (qv.y * qv.y + qv.z * qv.z)))
     } else {
         return SIMD3<Float> (
-            asinf (check) * radToDeg,
-            atan2f(2.0 * (qv.x * qv.z + qv.w * qv.y), 1.0 - 2.0 * (qv.x * qv.x + qv.y * qv.y)) * radToDeg,
-            atan2f(2.0 * (qv.x * qv.y + qv.w * qv.z), 1.0 - 2.0 * (qv.x * qv.x + qv.z * qv.z)) * radToDeg)
+            asinf (check),
+            atan2f(2.0 * (qv.x * qv.z + qv.w * qv.y), 1.0 - 2.0 * (qv.x * qv.x + qv.y * qv.y)),
+            atan2f(2.0 * (qv.x * qv.y + qv.w * qv.z), 1.0 - 2.0 * (qv.x * qv.x + qv.z * qv.z)))
     }
 
 }

--- a/Tests/RealityActionsTests/RealityActionsTests.swift
+++ b/Tests/RealityActionsTests/RealityActionsTests.swift
@@ -2,11 +2,16 @@ import XCTest
 @testable import RealityActions
 
 final class RealityActionsTests: XCTestCase {
-    func testExample() throws {
-        // XCTest Documentation
-        // https://developer.apple.com/documentation/xctest
-
-        // Defining Test Cases and Test Methods
-        // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
+    
+    func testQuatMath() throws {
+        let euler : SIMD3<Float> = SIMD3<Float>(.pi, .pi * 1.5, .pi / 2.0)
+        
+        let quat = quaternionFromEuler(angles: euler)
+        
+        let result = toEulerAngles(quat)
+        
+        XCTAssertEqual(euler.x, result.x, accuracy: Float.ulpOfOne)
+        XCTAssertEqual(euler.y, result.y, accuracy: Float.ulpOfOne)
+        XCTAssertEqual(euler.z, result.z, accuracy: Float.ulpOfOne)
     }
 }


### PR DESCRIPTION
* Some refactoring to use TimeInterval wherever appropriate (durations, etc), and Double instead of Float for most other things.

* ActionTween continues to tween a Float value because RealityKit tends to use Float for most of its components within Transforms, SIMD3<Float>, etc.
* For the RotateBy/RotateTo I've added overloads of the initialiser that allow angles in Radians to be provided.  This meant some internal changes so that Radians are used internally.  I've deliberately kept the original initialiser as accepting angles in Degrees so that it is backwards compatible.
* Added a simple test to verify that the alterations I did to the QuatMath hadn't broken anything.

It seems like a lot of change, but its a fairly simple quality of life change in that the repeated casting between TimeInterval and Float to use this wonderful Package is eliminated without any real impact to its function.